### PR TITLE
fix URLSearchParams for body

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -47,7 +47,7 @@ export const createClient = <R = any>(clientOptions: ClientOptions<R>) => {
         }
 
         const response = await fetch(endpoint, {
-          body: body ? JSON.stringify(body) : undefined,
+          body: body ? (body instanceof URLSearchParams ? body : JSON.stringify(body)) : undefined,
           cache: options.cache,
           credentials: options.credentials,
           headers: { ...{ 'Content-Type': 'application/json; charset=utf-8' }, ...headers },


### PR DESCRIPTION
The `body` field in the `RequestInit` interface is of type `string | URLSearchParams | Blob | Array | BufferView | ArrayBuffer | FormData | ReadableStream<Uint8Array> | null | undefined`.

Current implementation will use `JSON.stringify` for any type of `body` which is not correct. It is impossible to override it without modifying the source code. The `body` will always have type `string`.

If the `Content-Type` is `application/json` then the `body` should have type `string` (since a JSON is a single string and not really an JavaScript object as such). Practically you `JSON.stringify` a JavaScript object as done in current implementation.

But as said, current implementation will use `JSON.stringify` for any type of `body`. Here is an example of failure: 

If my `Content-Type` is `application/x-www-form-urlencoded` and I use `body: new URLSearchParams(params),` then the lib will do `body: JSON.stringify(new URLSearchParams(params)),` which leads to an empty JSON string body `"{}"`.

To **really** fix the issue, `body: body ? JSON.stringify(body): undefined,` in `client.ts` should be `body: body,` (or `body,`). The user has to manage it's `body`. But this could potentially be a **breaking change**.

**This PR** only fixes the issue  when using `URLSearchParams` as `body` type **without breaking anything** (until a better solution is chosen).

