### PR TITLE
Observe action by value instead reference

### DIFF
--- a/src/hooks/useQuery/useQuery.ts
+++ b/src/hooks/useQuery/useQuery.ts
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useReducer, useRef } from 'react';
 
+import { convertActionToBase64 } from '../../cache/cache';
 import { Action, QueryResponse } from '../../client/client.types';
 import { QueryError } from '../../client/errors/QueryError';
 import { ClientContext } from '../../context/clientContext/clientContext';
@@ -27,7 +28,7 @@ export const useQuery = <T = any, R = {}>(action: Action<R>, initFetch = true) =
     return () => {
       isMounted.current = false;
     };
-  }, [action]);
+  }, [convertActionToBase64(action)]);
 
   const handleQuery = useCallback(async () => {
     if (!isMounted.current) {
@@ -43,7 +44,7 @@ export const useQuery = <T = any, R = {}>(action: Action<R>, initFetch = true) =
     }
 
     return queryResponse;
-  }, [action]);
+  }, [convertActionToBase64(action)]);
 
   if (state.response && state.response.errorObject && state.response.errorObject instanceof QueryError) {
     throw state.response.errorObject;

--- a/src/hooks/useSuspenseQuery/useSuspenseQuery.ts
+++ b/src/hooks/useSuspenseQuery/useSuspenseQuery.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
-import { createCache } from '../../cache/cache';
+import { convertActionToBase64, createCache } from '../../cache/cache';
 import { Action, QueryResponse } from '../../client/client.types';
 import { QueryError } from '../../client/errors/QueryError';
 import { ClientContext } from '../../context/clientContext/clientContext';
@@ -24,7 +24,7 @@ export const useSuspenseQuery = <T, R = any>(action: Action<R>) => {
     return () => {
       cache.remove(action);
     };
-  }, [action]);
+  }, [convertActionToBase64(action)]);
 
   const forceQuery = () => {
     cache.remove(action);


### PR DESCRIPTION
**Issue:**

`useQuery` is triggered on reference changes of the `action` object and not by value changes. The reason is that `useEffect` uses `Object.is` to compare its reactive dependencies. In short, objects, arrays, and functions are compared by reference and booleans, strings and numbers by value.

Example of how `Object.is` works:

```typescript
const foo = { a: 1 };
const bar = { a: 1 };

Object.is(foo, foo);    // true (same reference)
Object.is(foo, bar);    // false (different reference)

const fee = foo;
foo.a = 2;
Object.is(foo, fee);    // true (same reference)
```

- If I change the value of e.g. `action.endpoint` then `useQuery` will do nothing. `useEffect` inside `useQuery` will not fire since the reference of the `action` object is still the same.

- Furthermore, `useQuery` will refetch if I pass an action with the same values but with a different reference. A refetch is in this case not needed.


**Practically:** 

if I have: 

```typescript
export function getUser(id: string): Action {
    return {
        endpoint: `/user/${id}`,
        method: 'GET',
    };
}
```

then I must use `useMemo` in order to avoid unnecessary refetch:

```typescript
const action = useMemo(() => getUser(id), [id]);
const { payload, loading, error } = useQuery<User>(action);
```

Doing this will probably result in infinite refetch and browser crash:

```typescript
const action = getUser(id);
const { payload, loading, error } = useQuery<User>(action);
```


**Fix:**

Convert `action` to base64 string as done in `client.ts`. Strings are always compared by value and not reference.

```typescript
const foo = 'test';
const bar = 'test';

Object.is(foo, bar);    // true
Object.is(foo, foo);    // true

const fee = foo;
fee += 'o';
Object.is(foo, fee);    // false
```

This commit fixes those two issues by converting the `action` to a base64 string at the `useEffect` dependencies inside `useQuery` and `useSuspenseQuery`. With this fix hacks like the above `useMemo` are gone.


