### PR TITLE
Custom response types for client query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 coverage
+.idea/

--- a/__tests__/src/client/client.test.ts
+++ b/__tests__/src/client/client.test.ts
@@ -200,4 +200,25 @@ describe('Client test', () => {
     expect(queryResponse.payload).toEqual('User Name');
     queryResponse.headers && expect(queryResponse.headers.get('Content-Length')).toEqual('9');
   });
+
+  it('resolve a response correctly to a blob', async () => {
+    const action: Action = {
+      method: 'GET',
+      endpoint: 'http://example.com/user/blob',
+      responseType: 'blob',
+    };
+
+    fetchMock.get(action.endpoint, async () => 'example');
+
+    const client = createClient({});
+
+    const queryResponse = await client.query<Blob>(action);
+
+    if(queryResponse && queryResponse.payload) {
+      expect(queryResponse.payload.constructor.name).toEqual('Blob');
+    } else {
+      throw Error('Something went wrong resolving the response to a blob')
+    }
+
+  });
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -356,7 +356,7 @@ Available hooks
 
 ## useQuery
 
-This hook is used to query data (can be used to get data from API and mutate data as well) . By default request is sent immediately (`initFetch = true`). You can turn on lazy loading by setting second param as `false`. Response of hook is [`QueryResponse`][] extended by `query` function which allows you to re-run query again or first time (when lazy loading is turned on), `abort` function to abort pending request and `reset` function to reset state of hook. First param of this hook is [`Action`][]
+This hook is used to query data (can be used to get data from API and mutate data as well) . By default request is sent immediately (`initFetch = true`). You can turn on lazy loading by setting second param as `false`. Response of hook is [`QueryResponse`][] extended by `query` function which allows you to re-run query again or first time (when lazy loading is turned on), `abort` function to abort pending request, `reset` function to reset state of hook and `loading` boolean to indicate if the query is still in progress. First param of this hook is [`Action`][]
 
 ```js
 import { useQuery } from 'react-fetching-library';

--- a/src/client/client.types.ts
+++ b/src/client/client.types.ts
@@ -1,6 +1,7 @@
 import { Cache } from '../cache/cache.types';
 
 type Method = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
+export type ResponseType = 'arrayBuffer' | 'blob' | 'json' | 'text' | 'formData';
 
 export type ActionConfig = {
   emitErrorForStatuses?: number[];
@@ -22,6 +23,7 @@ export type Action<T = any> = {
   signal?: AbortSignal | null;
   window?: any;
   config?: ActionConfig;
+  responseType: ResponseType;
 } & T;
 
 export type QueryResponse<T = any> = {

--- a/src/client/client.types.ts
+++ b/src/client/client.types.ts
@@ -32,6 +32,13 @@ export type QueryResponse<T = any> = {
   headers?: Headers;
 };
 
+export type UseQueryResponse<T> = {
+  loading: boolean;
+  abort: () => void;
+  reset: () => void;
+  query: () => Promise<QueryResponse<T>>;
+} & QueryResponse<T>;
+
 export type Client<R = any> = {
   query: <T>(action: Action<R>, skipCache?: boolean) => Promise<QueryResponse<T>>;
   cache?: Cache<QueryResponse>;

--- a/src/client/client.types.ts
+++ b/src/client/client.types.ts
@@ -23,7 +23,7 @@ export type Action<T = any> = {
   signal?: AbortSignal | null;
   window?: any;
   config?: ActionConfig;
-  responseType: ResponseType;
+  responseType?: ResponseType;
 } & T;
 
 export type QueryResponse<T = any> = {

--- a/src/hooks/useQuery/useQuery.ts
+++ b/src/hooks/useQuery/useQuery.ts
@@ -1,14 +1,14 @@
 import { useCallback, useContext, useEffect, useReducer, useRef } from 'react';
 
 import { convertActionToBase64 } from '../../cache/cache';
-import { Action, QueryResponse } from '../../client/client.types';
+import { Action, QueryResponse, UseQueryResponse } from '../../client/client.types';
 import { QueryError } from '../../client/errors/QueryError';
 import { ClientContext } from '../../context/clientContext/clientContext';
 import { RESET, RESET_LOADING, responseReducer, SET_LOADING, SET_RESPONSE } from '../../reducers/responseReducer';
 import { ResponseReducer } from '../../reducers/responseReducer.types';
 import { useCachedResponse } from '../useCachedResponse/useCachedResponse';
 
-export const useQuery = <T = any, R = {}>(action: Action<R>, initFetch = true) => {
+export const useQuery = <T = any, R = {}>(action: Action<R>, initFetch = true): UseQueryResponse<T> => {
   const clientContext = useContext(ClientContext);
   const cachedResponse = useCachedResponse<T>(action);
   const isMounted = useRef(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,11 @@ export * from './context/queryContext/queryContext';
 export * from './context/mutationContext/mutationContext';
 
 // typings
-export { Action, ClientOptions, QueryResponse, UseQueryResponse, RequestInterceptor, ResponseInterceptor } from './client/client.types';
+export {
+  Action,
+  ClientOptions,
+  QueryResponse,
+  UseQueryResponse,
+  RequestInterceptor,
+  ResponseInterceptor,
+} from './client/client.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,4 @@ export * from './context/queryContext/queryContext';
 export * from './context/mutationContext/mutationContext';
 
 // typings
-export { Action, ClientOptions, QueryResponse, RequestInterceptor, ResponseInterceptor } from './client/client.types';
+export { Action, ClientOptions, QueryResponse, UseQueryResponse, RequestInterceptor, ResponseInterceptor } from './client/client.types';


### PR DESCRIPTION
This merge request should address #56

Added a `responseType` property to the `Action` allowing to resolve a response to a specific data type, .i.e. `'arrayBuffer' | 'blob' | 'json' | 'text' | 'formData'`. I included a test for resolving a response to a blob. 

Furthermore, I also update the documentation on `useQuery` hook to included the `loaded` boolean value as part of the returned object and created a type for the `useQuery` return value (`UseQueryResponse<T>`).