### PR TITLE
Add a default value for the createClient options argument

### DIFF
--- a/__tests__/src/client/client.test.ts
+++ b/__tests__/src/client/client.test.ts
@@ -15,7 +15,7 @@ describe('Client test', () => {
       users: [],
     });
 
-    const client = createClient({});
+    const client = createClient();
 
     const queryResponse = await client.query(action);
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -19,7 +19,7 @@ export type HandleResponseInterceptors<R> = (
   interceptors: Array<ResponseInterceptor<R, any>>,
 ) => Promise<QueryResponse<any>>;
 
-export const createClient = <R = any>(clientOptions: ClientOptions<R>) => {
+export const createClient = <R = any>(clientOptions: ClientOptions<R> = {}) => {
   const cache = clientOptions.cacheProvider;
 
   const handleRequestInterceptors: HandleRequestInterceptors<R> = async (action, interceptors) => {


### PR DESCRIPTION
Since by default, all properties of the `createClient` argument are optional, in this PR I'm making the whole argument optional by adding a default value. I've spent some minutes trying to figure out, why things were not working when I tried the lib.

Very cool library btw 👍 