### PR TITLE
Reset reducer when action changes in useQuery

### DIFF
--- a/__tests__/src/hooks/useQuery/useQuery.test.tsx
+++ b/__tests__/src/hooks/useQuery/useQuery.test.tsx
@@ -249,21 +249,27 @@ describe('useQuery test', () => {
       wrapper: localWrapper,
       initialProps: action,
     });
+    expect(result.current.loading).toBe(true);
     expect(result.current.payload).toBe(undefined);
 
     await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
     expect(result.current.payload).toStrictEqual({ foo: 'bar' });
 
     rerender(anotherAction);
-    expect(result.current.payload).toStrictEqual({ foo: 'bar' });
+    expect(result.current.loading).toBe(true);
+    expect(result.current.payload).toBe(undefined);
 
     await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
     expect(result.current.payload).toStrictEqual({ bar: 'baz' });
 
     rerender(action);
+    expect(result.current.loading).toBe(false);
     expect(result.current.payload).toStrictEqual({ foo: 'bar' });
 
     rerender(anotherAction);
+    expect(result.current.loading).toBe(false);
     expect(result.current.payload).toStrictEqual({ bar: 'baz' });
   });
 

--- a/src/hooks/useQuery/useQuery.ts
+++ b/src/hooks/useQuery/useQuery.ts
@@ -23,6 +23,7 @@ export const useQuery = <T = any, R = any>(action: Action<T, R>, initFetch = tru
   const prevCacheKey = useRef<string>(cacheKey);
   if (cacheKey !== prevCacheKey.current) {
     prevCacheKey.current = cacheKey;
+    dispatch({ type: RESET });
     if (cachedResponse) {
       dispatch({ type: SET_RESPONSE, response: cachedResponse });
     }


### PR DESCRIPTION
Follow-up on https://github.com/marcin-piela/react-fetching-library/pull/110#discussion_r553937768. I left this out of #110 because I wasn't sure if this was by-design or not.

Currently, when `action` changes, `useQuery` will return the previous payload until a new payload is loaded.

It can make the UI feel a little less responsive since the payload doesn't get reset, but it is possible to use `loading` to determine whether or not to ignore the existing `payload`. So, I'm not sure if this is the expected behavior or not.

This change simply resets the reducer when the action changes, which results in the hook returning `undefined` until the new payload is loaded.

If, for some reason, people wanted the previous behavior, they'll need to store the payload in their component state:

```
const { payload } = useQuery(...);
const [cachedPayload, setCachedPayload] = useState<typeof payload>(payload);
if (payload !== cachedPayload) {
  setCachedPayload(payload);
}
```

I personally think that it is better that the hook's output always reflects its input. Since `useReducer` creates state in the hook  that should depend on the input, but it only does that on initialization of the hook. This is also an issue with `useState` and the motivation for hooks like `useStateWithDeps` (https://www.npmjs.com/package/use-state-with-deps).

