### PR TITLE
Update peer dependencies to support React 17 and React-Dom 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "typescript": "3.7.5"
   },
   "peerDependencies": {
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react": ">=16.8.4",
+    "react-dom": ">=16.8.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview:
Thanks for this project! We use it heavily in a number of our projects. With the recent release of NPM 7 we have gone through the process of updating a number of our dependencies. NPM 7 automatically installs peer dependencies which causes issues with projects that want to use React 17. This shouldn't be a breaking change and React 17 in itself is relatively lightweight and does not contain any new developer features. Let me know if this makes sense!

## Testing
Tested locally

## Notes:
I also considered using `^16.8.4 || ^17.0.0` to be more strict but leaned towards `>=` for flexibility.


