### PR TITLE
Can't send strings of JSON via API requests

### DIFF
--- a/__tests__/src/client/client.test.ts
+++ b/__tests__/src/client/client.test.ts
@@ -183,6 +183,24 @@ describe('Client test', () => {
     queryResponse.headers && expect(queryResponse.headers.get('Content-Length')).toEqual('20');
   });
 
+  it('does not stringify ndjson', async () => {
+    const action: Action = {
+      method: 'POST',
+      endpoint: 'http://example.com/user/ndjson',
+      headers: { 'Content-Type': 'application/x-ndjson' },
+      body: "{\"foo\": 1}\n{\"bar\": 2}",
+    };
+
+    fetchMock.post(action.endpoint, action.body);
+
+    const client = createClient({});
+
+    const queryResponse = await client.query(action);
+
+    expect(queryResponse.payload).toEqual("{\"foo\": 1}\n{\"bar\": 2}");
+    queryResponse.headers && expect(queryResponse.headers.get('Content-Length')).toEqual('21');
+  });
+
   it('responses with corect payload for custom content type', async () => {
     const action: Action = {
       method: 'POST',

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -61,7 +61,7 @@ export const createClient = <R = any>(clientOptions: ClientOptions<R> = {}) => {
           headers = { ...{ 'Content-Type': 'application/json; charset=utf-8' }, ...options.headers };
         }
 
-        const shouldStringify = headers && headers['Content-Type'] && headers['Content-Type'].indexOf('json') !== -1;
+        const shouldStringify = headers && headers['Content-Type'] && /\bjson\b/.test(headers['Content-Type']);
         const fetchFunction = clientOptions.fetch || fetch;
 
         const response = await fetchFunction(endpoint, {


### PR DESCRIPTION
I'm trying to implement `useMutation` to send a POST request to an API with a string containing newline-separated JSON. I found that the the string I provided was being quoted without me requesting so. I finally tracked it down to [this line of code](https://github.com/marcin-piela/react-fetching-library/blob/9b0abd81cf7494931ca144a1d64952f6e0d77b18/src/client/client.ts#L64) which checks if the content type contains the string `"json"` and if so, `JSON.stringify` will be called on the body.

Since the content type used is `application/x-ndjson`, this stringification happens in my case when I don't want it to. If this were just JSON, I could (accepting some extra overhead), parse the JSON and then pass the resulting object to allow it be converted back to a string. However, since I'm dealing with multiple JSON objects, I can't do that.

For now, I can modify my server so it will accept an alternate content type which does not contain `json`, but it would be nice to have a cleaner solution. The most obvious fix would be to have stringification be an option instead of automatic, but this would be a breaking change. A better solution might be instead of checking if the content type contains the string `json`, to check if it matches the regex `/\bjson\b/`.

This would allow all of the following content types to match:

* application/json
* text/x-json
* application/ld+json

This should handle all normal use cases where stringification is required, but will not match `application/x-ndjson`, which cannot be properly handled by stringification anyway.